### PR TITLE
Documented failing cases for ConcatStatement

### DIFF
--- a/.changeset/legal-jobs-brake.md
+++ b/.changeset/legal-jobs-brake.md
@@ -1,0 +1,5 @@
+---
+"ember-codemod-sort-invocations": patch
+---
+
+Documented failing cases for ConcatStatement

--- a/src/utils/sort-invocations/sort-attributes.ts
+++ b/src/utils/sort-invocations/sort-attributes.ts
@@ -65,6 +65,10 @@ export function sortAttributes(attributes: Attribute[]): Attribute[] {
     const { name, value } = attribute;
 
     switch (value.type) {
+      case 'ConcatStatement': {
+        return AST.builders.attr(name, AST.builders.concat(value.parts));
+      }
+
       case 'TextNode': {
         // Bug in @glimmer/syntax@0.84.3 (it removes values that are an empty string)
         if (value.chars === '') {

--- a/src/utils/sort-invocations/sort-attributes.ts
+++ b/src/utils/sort-invocations/sort-attributes.ts
@@ -64,15 +64,21 @@ export function sortAttributes(attributes: Attribute[]): Attribute[] {
   return attributes.sort(compareAttributes).map((attribute) => {
     const { name, value } = attribute;
 
-    // Bug in @glimmer/syntax@0.84.3 (it removes values that are an empty string)
-    if (value.type === 'TextNode' && value.chars === '') {
-      const { start, end } = value.loc;
+    switch (value.type) {
+      case 'TextNode': {
+        // Bug in @glimmer/syntax@0.84.3 (it removes values that are an empty string)
+        if (value.chars === '') {
+          const { start, end } = value.loc;
 
-      const isValueUndefined =
-        start.line === end.line && start.column === end.column;
+          const isValueUndefined =
+            start.line === end.line && start.column === end.column;
 
-      if (!isValueUndefined) {
-        return AST.builders.attr(name, AST.builders.text('<EMPTY STRING>'));
+          if (!isValueUndefined) {
+            return AST.builders.attr(name, AST.builders.text('<EMPTY STRING>'));
+          }
+        }
+
+        break;
       }
     }
 

--- a/src/utils/sort-invocations/sort-attributes.ts
+++ b/src/utils/sort-invocations/sort-attributes.ts
@@ -65,10 +65,6 @@ export function sortAttributes(attributes: Attribute[]): Attribute[] {
     const { name, value } = attribute;
 
     switch (value.type) {
-      case 'ConcatStatement': {
-        return AST.builders.attr(name, AST.builders.concat(value.parts));
-      }
-
       case 'TextNode': {
         // Bug in @glimmer/syntax@0.84.3 (it removes values that are an empty string)
         if (value.chars === '') {

--- a/tests/fixtures/my-app/input/app/templates/example-04.hbs
+++ b/tests/fixtures/my-app/input/app/templates/example-04.hbs
@@ -1,0 +1,31 @@
+{{! Ideal case }}
+<MyComponent
+  @parentContainerId={{concat "#" @parentId}}
+  @isOpen={{this.isOpen}}
+/>
+
+<MyComponent
+  @style={{concat "." @type "1"}}
+  @isOpen={{this.isOpen}}
+/>
+
+<input
+  type="tel"
+  local-class="input {{concat 'flag-' @country}}"
+/>
+
+{{! String concatenations }}
+<MyComponent
+  @parentContainerId="#{{@parentId}}"
+  @isOpen={{this.isOpen}}
+/>
+
+<MyComponent
+  @style=".{{@type}}1"
+  @isOpen={{this.isOpen}}
+/>
+
+<input
+  type="tel"
+  local-class="input flag-{{@country}}"
+/>

--- a/tests/fixtures/my-app/output/app/templates/example-04.hbs
+++ b/tests/fixtures/my-app/output/app/templates/example-04.hbs
@@ -1,0 +1,25 @@
+{{! Ideal case }}
+<MyComponent
+  @isOpen={{this.isOpen}} @parentContainerId={{concat "#" @parentId}}
+/>
+
+<MyComponent
+  @isOpen={{this.isOpen}} @style={{concat "." @type "1"}}
+/>
+
+<input
+  local-class="input {{concat 'flag-' @country}}" type="tel"
+/>
+
+{{! String concatenations }}
+<MyComponent
+  @isOpen={{this.isOpen}} @parentContainerId="{{@parentId}}"
+/>
+
+<MyComponent
+  @isOpen={{this.isOpen}} @style="{{@type}}"
+/>
+
+<input
+  local-class="input flag-{{@country}}" type="tel"
+/>


### PR DESCRIPTION
There is another bug in `@glimmer/syntax` or `ember-template-recast`, one that `ember-codemod-sort-invocations` can't easily fix.

If an argument value is a string concatenated without using the `{{concat}}` helper, and if that string has exactly 1 character before or after a `MustacheStatement`, then `ember-template-recast` will remove the single character before or after.

```hbs
{{! Before }}
<MyComponent
  @parentContainerId="#{{@parentId}}"
  @isOpen={{this.isOpen}}
/>

{{! After }}
<MyComponent
  @isOpen={{this.isOpen}} @parentContainerId="{{@parentId}}"
/>
```

The current fix is for end-developers to refactor code. See [Use `{{concat}}` helper to group substrings](https://github.com/ijlee2/embroider-css-modules/blob/2.0.22/docs/written-guides/refactor-code.md#use-concat-helper-to-group-substrings).
