### PR TITLE
Listed ...attributes last

### DIFF
--- a/.changeset/puny-papers-report.md
+++ b/.changeset/puny-papers-report.md
@@ -1,0 +1,5 @@
+---
+"ember-codemod-sort-invocations": minor
+---
+
+Listed ...attributes last

--- a/src/steps/sort-invocations.ts
+++ b/src/steps/sort-invocations.ts
@@ -36,14 +36,61 @@ function updateTemplate(file: string): string {
 
     ElementNode(node) {
       const { attributes, modifiers } = node;
+      let isSorted = false;
 
       if (!canSkipSortAttributes(attributes)) {
         node.attributes = sortAttributes(attributes);
+        isSorted = true;
       }
 
       if (!canSkipSortModifiers(modifiers)) {
         node.modifiers = sortModifiers(modifiers);
+        isSorted = true;
       }
+
+      if (!isSorted) {
+        return;
+      }
+
+      const lastAttribute = node.attributes.at(-1)!;
+      const hasSplattributes = lastAttribute.name === '...attributes';
+
+      if (!hasSplattributes) {
+        return;
+      }
+
+      // The originally last attribute's location has the highest line number
+      const lineNumber = attributes.at(-1)!.loc.start.line;
+
+      node.attributes.splice(
+        -1,
+        1,
+        AST.builders.attr('...attributes', AST.builders.text(''), {
+          start: {
+            column: 0,
+            line: lineNumber + node.modifiers.length + 1,
+          },
+          end: {
+            column: '...attributes'.length,
+            line: lineNumber + node.modifiers.length + 1,
+          },
+        }),
+      );
+
+      node.modifiers = node.modifiers.map((modifier) => {
+        const { hash, loc, params, path } = modifier;
+
+        return AST.builders.elementModifier(path, params, hash, {
+          start: {
+            column: loc.start.column,
+            line: loc.start.line - 1,
+          },
+          end: {
+            column: loc.end.column,
+            line: loc.end.line - 1,
+          },
+        });
+      });
     },
 
     MustacheStatement(node) {

--- a/src/steps/sort-invocations.ts
+++ b/src/steps/sort-invocations.ts
@@ -10,6 +10,7 @@ import {
   canSkipSortAttributes,
   canSkipSortHash,
   canSkipSortModifiers,
+  listSplattributesLast,
   sortAttributes,
   sortHash,
   sortModifiers,
@@ -52,45 +53,10 @@ function updateTemplate(file: string): string {
         return;
       }
 
-      const lastAttribute = node.attributes.at(-1)!;
-      const hasSplattributes = lastAttribute.name === '...attributes';
-
-      if (!hasSplattributes) {
-        return;
-      }
-
       // The originally last attribute's location has the highest line number
       const lineNumber = attributes.at(-1)!.loc.start.line;
 
-      node.attributes.splice(
-        -1,
-        1,
-        AST.builders.attr('...attributes', AST.builders.text(''), {
-          start: {
-            column: 0,
-            line: lineNumber + node.modifiers.length + 1,
-          },
-          end: {
-            column: '...attributes'.length,
-            line: lineNumber + node.modifiers.length + 1,
-          },
-        }),
-      );
-
-      node.modifiers = node.modifiers.map((modifier) => {
-        const { hash, loc, params, path } = modifier;
-
-        return AST.builders.elementModifier(path, params, hash, {
-          start: {
-            column: loc.start.column,
-            line: loc.start.line - 1,
-          },
-          end: {
-            column: loc.end.column,
-            line: loc.end.line - 1,
-          },
-        });
-      });
+      listSplattributesLast(node, lineNumber);
     },
 
     MustacheStatement(node) {

--- a/src/utils/sort-invocations/index.ts
+++ b/src/utils/sort-invocations/index.ts
@@ -1,3 +1,4 @@
+export * from './list-splattributes-last.js';
 export * from './sort-attributes.js';
 export * from './sort-hash.js';
 export * from './sort-modifiers.js';

--- a/src/utils/sort-invocations/list-splattributes-last.ts
+++ b/src/utils/sort-invocations/list-splattributes-last.ts
@@ -1,0 +1,42 @@
+import { AST } from '@codemod-utils/ast-template';
+
+type ElementNode = ReturnType<typeof AST.builders.element>;
+
+export function listSplattributesLast(node: ElementNode, lineNumber: number) {
+  const lastAttribute = node.attributes.at(-1)!;
+  const hasSplattributes = lastAttribute.name === '...attributes';
+
+  if (!hasSplattributes) {
+    return;
+  }
+
+  node.attributes.splice(
+    -1,
+    1,
+    AST.builders.attr('...attributes', AST.builders.text(''), {
+      start: {
+        column: 0,
+        line: lineNumber + node.modifiers.length + 1,
+      },
+      end: {
+        column: '...attributes'.length,
+        line: lineNumber + node.modifiers.length + 1,
+      },
+    }),
+  );
+
+  node.modifiers = node.modifiers.map((modifier) => {
+    const { hash, loc, params, path } = modifier;
+
+    return AST.builders.elementModifier(path, params, hash, {
+      start: {
+        column: loc.start.column,
+        line: loc.start.line - 1,
+      },
+      end: {
+        column: loc.end.column,
+        line: loc.end.line - 1,
+      },
+    });
+  });
+}

--- a/src/utils/sort-invocations/sort-attributes.ts
+++ b/src/utils/sort-invocations/sort-attributes.ts
@@ -86,14 +86,14 @@ export function sortAttributes(attributes: Attribute[]): Attribute[] {
         const firstPart = value.parts[0];
         const newFirstPart = cloneIfTextNode(firstPart);
 
-        const lastPart = value.parts[value.parts.length - 1]!;
+        const lastPart = value.parts.at(-1)!;
         const newLastPart = cloneIfTextNode(lastPart);
 
         return AST.builders.attr(
           name,
           AST.builders.concat([
             newFirstPart,
-            ...value.parts.slice(1, value.parts.length - 1),
+            ...value.parts.slice(1, -1),
             newLastPart,
           ]),
         );

--- a/tests/fixtures/my-app/output/app/components/example-02.hbs
+++ b/tests/fixtures/my-app/output/app/components/example-02.hbs
@@ -9,11 +9,11 @@
 
 {{! Angle bracket syntax }}
 <Ui::Button
-  @label="Submit form" @type="submit" data-test-button ...attributes {{on "click" this.doSomething}}
+  @label="Submit form" @type="submit" data-test-button {{on "click" this.doSomething}} ...attributes
 />
 
 <Ui::Button
-  @type="submit" data-test-button={{""}} ...attributes {{on "click" this.doSomething}}
+  @type="submit" data-test-button={{""}} {{on "click" this.doSomething}} ...attributes
 >
   Submit form
 </Ui::Button>

--- a/tests/fixtures/my-app/output/app/components/example-03.hbs
+++ b/tests/fixtures/my-app/output/app/components/example-03.hbs
@@ -12,11 +12,11 @@
 
 {{! Angle bracket syntax }}
 <Ui::Button
-  @isDisabled={{true}} @label="Submit form" @type="submit" class="ui-button disabled" data-cucumber-button="Submit form" data-test-button ...attributes {{on "click" this.doSomething}}
+  @isDisabled={{true}} @label="Submit form" @type="submit" class="ui-button disabled" data-cucumber-button="Submit form" data-test-button {{on "click" this.doSomething}} ...attributes
 />
 
 <Ui::Button
-  @isDisabled={{true}} @type="submit" class="ui-button disabled" data-cucumber-button="Submit form" data-test-button={{""}} ...attributes {{on "click" this.doSomething}}
+  @isDisabled={{true}} @type="submit" class="ui-button disabled" data-cucumber-button="Submit form" data-test-button={{""}} {{on "click" this.doSomething}} ...attributes
 >
   Submit form
 </Ui::Button>

--- a/tests/fixtures/my-app/output/app/components/example-07.hbs
+++ b/tests/fixtures/my-app/output/app/components/example-07.hbs
@@ -9,11 +9,11 @@
 
 {{! Component as a property }}
 <this.MyButton
-  @label="Submit form" @type="submit" data-test-button ...attributes {{on "click" this.doSomething}}
+  @label="Submit form" @type="submit" data-test-button {{on "click" this.doSomething}} ...attributes
 />
 
 <this.MyButton
-  @type="submit" data-test-button ...attributes {{on "click" this.doSomething}}
+  @type="submit" data-test-button {{on "click" this.doSomething}} ...attributes
 >
   Submit form
 </this.MyButton>

--- a/tests/fixtures/my-app/output/app/components/example-11.gjs
+++ b/tests/fixtures/my-app/output/app/components/example-11.gjs
@@ -13,11 +13,11 @@ const ExampleComponent = <template>
 
   {{! Angle bracket syntax }}
   <UiButton
-    @label="Submit form" @type="submit" data-test-button ...attributes {{on "click" @onSubmit}}
+    @label="Submit form" @type="submit" data-test-button {{on "click" @onSubmit}} ...attributes
   />
 
   <UiButton
-    @type="submit" data-test-button ...attributes {{on "click" @onSubmit}}
+    @type="submit" data-test-button {{on "click" @onSubmit}} ...attributes
   >
     Submit form
   </UiButton>

--- a/tests/fixtures/my-app/output/app/components/example-12.gts
+++ b/tests/fixtures/my-app/output/app/components/example-12.gts
@@ -20,11 +20,11 @@ const ExampleComponent: TOC<ExampleSignature> = <template>
 
   {{! Angle bracket syntax }}
   <UiButton
-    @label="Submit form" @type="submit" data-test-button ...attributes {{on "click" @onSubmit}}
+    @label="Submit form" @type="submit" data-test-button {{on "click" @onSubmit}} ...attributes
   />
 
   <UiButton
-    @type="submit" data-test-button ...attributes {{on "click" @onSubmit}}
+    @type="submit" data-test-button {{on "click" @onSubmit}} ...attributes
   >
     Submit form
   </UiButton>

--- a/tests/fixtures/my-v2-addon/output/src/components/example-02.hbs
+++ b/tests/fixtures/my-v2-addon/output/src/components/example-02.hbs
@@ -9,11 +9,11 @@
 
 {{! Angle bracket syntax }}
 <Ui::Button
-  @label="Submit form" @type="submit" data-test-button ...attributes {{on "click" this.doSomething}}
+  @label="Submit form" @type="submit" data-test-button {{on "click" this.doSomething}} ...attributes
 />
 
 <Ui::Button
-  @type="submit" data-test-button={{""}} ...attributes {{on "click" this.doSomething}}
+  @type="submit" data-test-button={{""}} {{on "click" this.doSomething}} ...attributes
 >
   Submit form
 </Ui::Button>

--- a/tests/fixtures/my-v2-addon/output/src/components/example-03.hbs
+++ b/tests/fixtures/my-v2-addon/output/src/components/example-03.hbs
@@ -12,11 +12,11 @@
 
 {{! Angle bracket syntax }}
 <Ui::Button
-  @isDisabled={{true}} @label="Submit form" @type="submit" class="ui-button disabled" data-cucumber-button="Submit form" data-test-button ...attributes {{on "click" this.doSomething}}
+  @isDisabled={{true}} @label="Submit form" @type="submit" class="ui-button disabled" data-cucumber-button="Submit form" data-test-button {{on "click" this.doSomething}} ...attributes
 />
 
 <Ui::Button
-  @isDisabled={{true}} @type="submit" class="ui-button disabled" data-cucumber-button="Submit form" data-test-button={{""}} ...attributes {{on "click" this.doSomething}}
+  @isDisabled={{true}} @type="submit" class="ui-button disabled" data-cucumber-button="Submit form" data-test-button={{""}} {{on "click" this.doSomething}} ...attributes
 >
   Submit form
 </Ui::Button>

--- a/tests/fixtures/my-v2-addon/output/src/components/example-07.hbs
+++ b/tests/fixtures/my-v2-addon/output/src/components/example-07.hbs
@@ -9,11 +9,11 @@
 
 {{! Component as a property }}
 <this.MyButton
-  @label="Submit form" @type="submit" data-test-button ...attributes {{on "click" this.doSomething}}
+  @label="Submit form" @type="submit" data-test-button {{on "click" this.doSomething}} ...attributes
 />
 
 <this.MyButton
-  @type="submit" data-test-button ...attributes {{on "click" this.doSomething}}
+  @type="submit" data-test-button {{on "click" this.doSomething}} ...attributes
 >
   Submit form
 </this.MyButton>


### PR DESCRIPTION
## Background

Patches #1. Because `ember-template-recast` considers `...attributes` as an `AttrNode`, we need to manually move its location if an invocation includes a modifier.
